### PR TITLE
implement work-around for editor loading without content

### DIFF
--- a/content-manager/admin/src/components/WysiwygWithErrors/Tinymce.js
+++ b/content-manager/admin/src/components/WysiwygWithErrors/Tinymce.js
@@ -57,7 +57,7 @@ const Editor = ({ onChange, name, value }) => {
 Editor.propTypes = {
   onChange: PropTypes.func.isRequired,
   name: PropTypes.string.isRequired,
-  value: PropTypes.string.isRequired,
+  value: PropTypes.string,
 };
 
 export default Editor;

--- a/content-manager/admin/src/components/WysiwygWithErrors/index.js
+++ b/content-manager/admin/src/components/WysiwygWithErrors/index.js
@@ -6,6 +6,8 @@ import { Label, InputDescription, InputErrors } from 'strapi-helper-plugin';
 import Editor from './Tinymce';
 import MediaLib from './MediaLib';
 
+let passes = {};
+
 const WysiwygWithErrors = ({
   inputDescription,
   errors,
@@ -15,6 +17,15 @@ const WysiwygWithErrors = ({
   onChange,
   value,
 }) => {
+  if (!passes[name]) {
+    passes[name] = 0;
+  }
+  if (!value && passes[name] < 1) {
+    passes[name]++;
+    return (null);
+  }
+  passes[name] = 0;
+
   const [isOpen, setIsOpen] = useState(false);
   let spacer = !isEmpty(inputDescription) ? (
     <div style={{ height: '.4rem' }} />


### PR DESCRIPTION
Content loads into the editor fine the first time you open a page that contains an editor, but if you navigate to other pages and then come back, the content will not load in. This is a work-around for that. Would be great if someone who knows what is going on here could chime in. The value prop seems to always return null the first go-around. I believe this addresses #6 