### PR TITLE
Fixed: Editor is not populating current value!

### DIFF
--- a/content-manager/admin/src/components/WysiwygWithErrors/Tinymce.js
+++ b/content-manager/admin/src/components/WysiwygWithErrors/Tinymce.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Editor as Tinymce } from '@tinymce/tinymce-react';
 import styled from 'styled-components';
-import { auth } from 'strapi-helper-plugin';
 
 const Wrapper = styled.div`
   .ck-editor__main {
@@ -14,12 +13,10 @@ const Wrapper = styled.div`
 `;
 
 const Editor = ({ onChange, name, value }) => {
-  const jwtToken = auth.getToken();
   return (
     <>
       <Wrapper>
         <Tinymce
-          initialValue=""
           tinymceScriptSrc={strapi.backendURL + '/tinymce/js/tinymce/tinymce.min.js'}
           value={value}
           init={{

--- a/content-manager/admin/src/components/WysiwygWithErrors/index.js
+++ b/content-manager/admin/src/components/WysiwygWithErrors/index.js
@@ -58,7 +58,7 @@ const WysiwygWithErrors = ({
           Media Library
         </Button>
       </div>
-      <Editor name={name} onChange={onChange} value={value} />
+      <Editor name={name} onChange={onChange} value={value || ""} />
       <InputDescription
         message={inputDescription}
         style={!isEmpty(inputDescription) ? { marginTop: '1.4rem' } : {}}


### PR DESCRIPTION
Reference: #6 #7 

TinyMCE was not populating the saved data due to the initial value being set to an empty string. 

By removing the initialValue prop, TinyMCE component now rerenders the value on update.

Moreover, to fix the required `value` prop error which pops up in the console, we can provide a default empty strings value to Editor Component i.e. `<Editor name={name} onChange={onChange} value={value || ""} />`. This PR also fixes that too.  